### PR TITLE
Update TrueTypeFont.hx

### DIFF
--- a/glyphme/TrueTypeFont.hx
+++ b/glyphme/TrueTypeFont.hx
@@ -282,7 +282,7 @@ class TrueTypeFont extends h2d.Font {
 	public inline function getScaleForPixelHeight(info:TrueTypeFontInfo, height:Float) {
 		return switch (scaleMode) {
 			case Ascent:
-				height / info.ascent;
+				height / ( info.ascent - info.descent);
 			case AscentAndDescent:
 				height / (info.ascent + info.descent);
 			case Custom(getScale):


### PR DESCRIPTION
in stb_truetype.h

```
STBTT_DEF float stbtt_ScaleForPixelHeight(const stbtt_fontinfo *info, float height)
{
   int fheight = ttSHORT(info->data + info->hhea + 4) - ttSHORT(info->data + info->hhea + 6);
   return (float) height / fheight;
}
```

so need modify `getScaleForPixelHeight`
```
	public inline function getScaleForPixelHeight(info:TrueTypeFontInfo, height:Float) {
		return switch (scaleMode) {
			case Ascent:
				height / ( info.ascent - info.descent);
			case AscentAndDescent:
				height / (info.ascent + info.descent);
			case Custom(getScale):
				return getScale(info, height);
		}
	}
```

i fix it.